### PR TITLE
Remove Antergos and Audacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Omissions aren't on purpose, feel free to fork and add whatever I've missed.
 ## Linux Distros
 
 * [Arch Linux](https://www.archlinux.org/donate/)
-  * [Antergos](https://antergos.com/donate/)
   * [Apricity OS](https://apricityos.com/) - Donate button is in the upper right
   * [Chakra](https://chakralinux.org/?donate)
   * [Manjaro](https://manjaro.github.io/donate/)

--- a/README.md
+++ b/README.md
@@ -91,10 +91,6 @@ Omissions aren't on purpose, feel free to fork and add whatever I've missed.
 * [Wine](https://www.winehq.org/donate)
 * [WinSCP](https://winscp.net/eng/donate.php)
 
-### Audio
-
-* [Audacity](http://www.audacityteam.org/donate/)
-
 ### Browser Extensions
 
 * [Adblock Plus](https://adblockplus.org/en/contribute#donate)


### PR DESCRIPTION
Antergos project unfortunately is no more, it now appears to link to a spam-website, so I think that it's better to remove it.

Audacity no longer accepts monetary donations.

Adblock plus now has a premium subscription, but they no longer support donations. I didn't touch this one, but I think we should also remove it.